### PR TITLE
Add xfailed test that reproduces disconnection loop (issue #893)

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        python: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python: ["3.11", "3.12", "3.13", "3.14" ] #, "3.9", "3.10", ]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/tests/lib/conftest.py
+++ b/tests/lib/conftest.py
@@ -2,6 +2,7 @@ import os
 import signal
 import subprocess
 import sys
+import time
 
 import pytest
 
@@ -45,7 +46,29 @@ def alpn_ssl_server_socket(monkeypatch, ssl_certs_path):
     yield from _yield_server(monkeypatch, create_server_socket_ssl(path=ssl_certs_path, alpn_protocols=["paho-test-protocol"]))
 
 
-def stop_process(proc: subprocess.Popen) -> None:
+def terminate_process(proc: subprocess.Popen) -> None:
+    proc.terminate()
+    try:
+        # At least on Unix, terminate() isn't an unconditional kill, process
+        # could ignore/handle it.
+        proc.wait(1)
+    except subprocess.TimeoutExpired:
+        # So use kill which is unstoppable on Unix
+        proc.kill()
+        proc.wait(1)  # If here we timeout, there is nothing more to do.
+
+
+def stop_process(proc: subprocess.Popen, ready_file) -> None:
+    deadline = time.monotonic() + 5
+    while proc.poll() is None and not ready_file.exists():
+        if time.monotonic() >= deadline:
+            terminate_process(proc)
+            raise RuntimeError("Client did not become ready to stop")
+        time.sleep(0.01)
+
+    if proc.poll() is not None:
+        return
+
     if sys.platform == "win32":
         proc.send_signal(signal.CTRL_C_EVENT)
     else:
@@ -53,25 +76,19 @@ def stop_process(proc: subprocess.Popen) -> None:
     try:
         proc.wait(5)
     except subprocess.TimeoutExpired:
-        proc.terminate()
-        try:
-            # At least on Unix, terminate() isn't an unconditional kill, process
-            # could ignore/handle it.
-            proc.wait(1)
-        except subprocess.TimeoutExpired:
-            # So use kill which is unstoppable on Unix
-            proc.kill()
-            proc.wait(1)  # If here we timeout, there is nothing more to do.
+        terminate_process(proc)
 
 
 @pytest.fixture()
-def start_client(request: pytest.FixtureRequest, ssl_certs_path):
+def start_client(request: pytest.FixtureRequest, ssl_certs_path, tmp_path):
     def starter(name: str, expected_returncode: int = 0) -> None:
         client_path = clients_path / name
         if not client_path.exists():
             raise FileNotFoundError(client_path)
+        ready_file = tmp_path / f"{name}.ready"
         env = dict(
             os.environ,
+            PAHO_TEST_READY_FILE=str(ready_file),
             PAHO_SSL_PATH=str(ssl_certs_path),
             PYTHONPATH=f"{tests_path}{os.pathsep}{os.environ.get('PYTHONPATH', '')}",
         )
@@ -82,7 +99,7 @@ def start_client(request: pytest.FixtureRequest, ssl_certs_path):
         ], env=env)
 
         def fin():
-            stop_process(proc)
+            stop_process(proc, ready_file)
             # If return code is None, process had not stopped when a method was last called on proc.
             # https://docs.python.org/library/subprocess.html#subprocess.Popen.returncode
             if proc.returncode != expected_returncode:

--- a/tests/paho_test.py
+++ b/tests/paho_test.py
@@ -403,6 +403,13 @@ def pack_remaining_length(remaining_length):
             return s
 
 
+def signal_client_ready():
+    ready_file = os.environ.get("PAHO_TEST_READY_FILE")
+    if ready_file is not None:
+        with open(ready_file, "w"):
+            pass
+
+
 def loop_until_keyboard_interrupt(mqttc):
     """
     Call loop() in a loop until KeyboardInterrupt is received.
@@ -413,6 +420,7 @@ def loop_until_keyboard_interrupt(mqttc):
     and stop the client gracefully.
     """
     try:
+        signal_client_ready()
         while True:
             mqttc.loop()
     except KeyboardInterrupt:
@@ -431,6 +439,7 @@ def wait_for_keyboard_interrupt():
     """
     yield  # If we get a KeyboardInterrupt during the block, it's too soon!
     try:
+        signal_client_ready()
         while True:
             time.sleep(0.1)
     except KeyboardInterrupt:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -864,18 +864,18 @@ class TestCompatibility:
             disconnect_packet = paho_test.gen_disconnect()
             fake_broker.expect_packet("disconnect", disconnect_packet)
 
-            assert callback_called == [
-                "on_connect",
-                "on_subscribe",
-                "on_publish",
-                "on_message",
-                "on_unsubscribe",
-                "on_disconnect",
-            ]
-
         finally:
             mqttc.disconnect()
             mqttc.loop_stop()
+
+        assert callback_called == [
+            "on_connect",
+            "on_subscribe",
+            "on_publish",
+            "on_message",
+            "on_unsubscribe",
+            "on_disconnect",
+        ]
 
         packet_in = fake_broker.receive_packet(1)
         assert not packet_in  # Check connection is closed
@@ -1004,18 +1004,18 @@ class TestCompatibility:
             disconnect_packet = paho_test.gen_disconnect()
             fake_broker.expect_packet("disconnect", disconnect_packet)
 
-            assert callback_called == [
-                "on_connect",
-                "on_subscribe",
-                "on_publish",
-                "on_message",
-                "on_unsubscribe",
-                "on_disconnect",
-            ]
-
         finally:
             mqttc.disconnect()
             mqttc.loop_stop()
+
+        assert callback_called == [
+            "on_connect",
+            "on_subscribe",
+            "on_publish",
+            "on_message",
+            "on_unsubscribe",
+            "on_disconnect",
+        ]
 
         packet_in = fake_broker.receive_packet(1)
         assert not packet_in  # Check connection is closed

--- a/tests/test_mqttv5.py
+++ b/tests/test_mqttv5.py
@@ -23,10 +23,11 @@ import threading
 import time
 import unittest
 import unittest.mock
+import warnings
 
 import paho.mqtt
 import paho.mqtt.client
-from paho.mqtt.enums import CallbackAPIVersion
+from paho.mqtt.enums import CallbackAPIVersion, MQTTErrorCode
 from paho.mqtt.packettypes import PacketTypes
 from paho.mqtt.properties import Properties
 from paho.mqtt.subscribeoptions import SubscribeOptions
@@ -187,7 +188,19 @@ def cleanup(port):
     print("clean up finished")
 
 
-class Test(unittest.TestCase):
+class _TestBase(unittest.TestCase):
+
+    @staticmethod
+    def new_client(clientid):
+        callback = Callbacks()
+        client = paho.mqtt.client.Client(
+            CallbackAPIVersion.VERSION1,
+            clientid.encode("utf-8"),
+            protocol=paho.mqtt.client.MQTTv5,
+        )
+        callback.register(client)
+        client.loop_start()
+        return client, callback
 
     @classmethod
     def setUpClass(cls):
@@ -195,40 +208,17 @@ class Test(unittest.TestCase):
 
         sys.path.append("paho.mqtt.testing/interoperability/")
         try:
-            import mqtt.brokers
+            import mqtt.brokers  # noqa: F401  (populates sys.modules)
         except ImportError as ie:
             raise unittest.SkipTest("paho.mqtt.testing not present.") from ie
 
-        # Hack: we need to patch `signal.signal()` because `mqtt.brokers.run()`
-        #       calls it to set up a signal handler; however, that won't work
-        #       from a thread...
-        with unittest.mock.patch("signal.signal", unittest.mock.MagicMock()):
-            cls._test_broker = threading.Thread(
-                target=mqtt.brokers.run,
-                kwargs={
-                    "config": ["listener 0"],
-                },
-            )
-            cls._test_broker.daemon = True
-            cls._test_broker.start()
-            # Wait a bit for TCP server to bind to an address
-            for _ in range(20):
-                time.sleep(0.1)
-                if mqtt.brokers.listeners.TCPListeners.server is not None:
-                    port = mqtt.brokers.listeners.TCPListeners.server.socket.getsockname()[1]
-                    if port != 0:
-                        cls._test_broker_port = port
-                        break
-            else:
-                raise ValueError("can't find the test broker port")
+        cls._start_broker(port=0)
         setData()
         cleanup(cls._test_broker_port)
 
         callback = Callbacks()
         callback2 = Callbacks()
 
-        #aclient = mqtt_client.Client(b"\xEF\xBB\xBF" + "myclientid".encode("utf-8"))
-        #aclient = mqtt_client.Client("myclientid".encode("utf-8"))
         aclient = paho.mqtt.client.Client(CallbackAPIVersion.VERSION1, b"aclient", protocol=paho.mqtt.client.MQTTv5)
         callback.register(aclient)
 
@@ -236,11 +226,53 @@ class Test(unittest.TestCase):
         callback2.register(bclient)
 
     @classmethod
+    def _start_broker(cls, port):
+        """(Re)start mqtt.brokers.run in a daemon thread bound to `port`
+        (0 = OS picks one). Blocks until the listener is bound and sets
+        cls._test_broker / cls._test_broker_port."""
+        import socketserver
+
+        import mqtt.brokers
+        # Make sure the listening socket can be rebound immediately after
+        # server_close(), regardless of paho.mqtt.testing's own defaults.
+        socketserver.TCPServer.allow_reuse_address = True
+
+        with unittest.mock.patch("signal.signal", unittest.mock.MagicMock()):
+            cls._test_broker = threading.Thread(
+                target=mqtt.brokers.run,
+                kwargs={"config": [f"listener {port}"]},
+            )
+            cls._test_broker.daemon = True
+            cls._test_broker.start()
+
+            for _ in range(50):
+                time.sleep(0.1)
+                server = mqtt.brokers.listeners.TCPListeners.server
+                if server is not None:
+                    bound_port = server.socket.getsockname()[1]
+                    if bound_port != 0:
+                        cls._test_broker_port = bound_port
+                        return
+            raise ValueError("can't find the test broker port")
+
+    @classmethod
     def tearDownClass(cls):
         # Another hack to stop the test broker... we rely on fact that it use a sockserver.TCPServer
         import mqtt.brokers
         mqtt.brokers.listeners.TCPListeners.server.shutdown()
         cls._test_broker.join(5)
+
+    @classmethod
+    def _reboot_broker(cls):
+        import mqtt.brokers
+        server = mqtt.brokers.listeners.TCPListeners.server
+        server.shutdown()
+        server.server_close()
+        cls._test_broker.join(5)
+        cls._start_broker(port=cls._test_broker_port)
+
+
+class Test(_TestBase):
 
     def test_basic(self):
         import datetime
@@ -545,16 +577,6 @@ class Test(unittest.TestCase):
         aclient.loop_stop()
         self.assertEqual(len(msgs), 2)
 
-    def new_client(self, clientid):
-        callback = Callbacks()
-        client = paho.mqtt.client.Client(
-            CallbackAPIVersion.VERSION1,
-            clientid.encode("utf-8"),
-            protocol=paho.mqtt.client.MQTTv5,
-        )
-        callback.register(client)
-        client.loop_start()
-        return client, callback
 
     def test_session_expiry(self):
         # no session expiry property == never expire
@@ -1063,6 +1085,10 @@ class Test(unittest.TestCase):
             laclient.disconnect()
             lacallback.wait_disconnected()
             laclient.loop_stop()
+            warnings.warn(
+                f"Exiting test_client_topic_alias early. Broker does not support Topic alii. {clientTopicAliasMaximum=}",
+                stacklevel=2,
+            )
             return
 
         laclient.subscribe(topics[0], qos=2)
@@ -1400,6 +1426,99 @@ class Test(unittest.TestCase):
         lbclient.disconnect()
         lbcallback.wait_disconnected()
         lbclient.loop_stop()
+
+
+class _TestBrokerRebootsTopicAliiMixin:
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        clientid = f'client topic alias broker shutsdown QoS: {cls.qos}'
+
+        laclient, lacallback = cls.new_client(f"{clientid} a")
+        laclient.connect(host="localhost", port=cls._test_broker_port)
+        _connack = lacallback.wait_connected()
+        print("laclient Connected", flush=True)
+
+
+        publish_properties = Properties(PacketTypes.PUBLISH)
+        publish_properties.TopicAlias = 1
+
+
+        laclient.subscribe(topics[0], qos=2)
+        lacallback.wait_subscribed()
+
+        laclient.publish(topics[0], b"topic alias 1",
+                         cls.qos, properties=publish_properties)
+        lacallback.messages.get(timeout=DEFAULT_TIMEOUT)
+
+        for i in range(2,6):
+            laclient.publish("", f"topic alias msg {i}".encode("ascii"), cls.qos,
+                         properties=publish_properties)
+            lacallback.messages.get(timeout=DEFAULT_TIMEOUT)
+
+        # Simulate PUBACK being lost
+        laclient._tmp_do_on_publish = laclient._do_on_publish
+        with laclient._callback_mutex, laclient._in_callback_mutex, laclient._out_message_mutex:
+            laclient._do_on_publish = lambda mid, rc, props : MQTTErrorCode.MQTT_ERR_SUCCESS
+
+
+
+        msg_info = laclient.publish("", "topic alias msg 6".encode("ascii"), cls.qos,
+                        properties=publish_properties)
+
+        time.sleep(0.3)
+
+        if cls.qos >= 1:
+            # Assertion error will be ignored in setUp()
+            laclient._out_messages[msg_info.mid]
+
+        # Do not get last message...  ... in QoS >= 1, expect
+        # this to causes client to get stuck in a loop:
+        # i) reconnection
+        # ii) publish QoS >= 1 message with no PUBACK to unrecognised alias
+        # iii) Broker kicks client
+        print("Rebooting broker...")
+        cls._reboot_broker()
+
+        lacallback.wait_disconnected()
+        _connack = lacallback.wait_connected()
+
+        cls.laclient, cls.lacallback = laclient, lacallback
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.laclient.loop_stop()
+        super().tearDownClass()
+
+class TestBrokerRebootsTopicAliiQoS0(_TestBrokerRebootsTopicAliiMixin, _TestBase):
+    """ Simulates what happens when broker reboots on
+        a QoS 0 client, that has had the code to clear the message
+        queue on PUBACK deactivated.
+    """
+    qos=0
+    def test_qos0_client_reconnects_after_broker_reboots(self):
+        time.sleep(DEFAULT_TIMEOUT)
+        self.assertTrue(self.lacallback.disconnecteds.empty())
+
+class TestBrokerRebootsTopicAliiQoS1(_TestBrokerRebootsTopicAliiMixin, _TestBase):
+    """ Simulated what happens when broker reboots on
+        a QoS 1 client, that has had the code to clear the message
+        queue on PUBACK deactivated.
+
+        Note, on a similar class for QoS 2, the test setUpClass
+        hangs or enters an infinite loop, causing the whole test
+        session to time out.  So there is never
+        anything for the xfail to test.
+    """
+
+    qos=1
+    @unittest.expectedFailure
+    def test_qos1_client_reconnects_after_broker_reboots(self):
+        time.sleep(DEFAULT_TIMEOUT)
+        self.assertTrue(self.lacallback.disconnecteds.empty())
+
+
+
 
 
 def setData():

--- a/tests/testsupport/broker.py
+++ b/tests/testsupport/broker.py
@@ -59,8 +59,10 @@ class FakeBroker:
         if self._conn is None:
             raise ValueError('Connection is not open')
 
-        packet_in = self._conn.recv(num_bytes)
-        return packet_in
+        try:
+            return self._conn.recv(num_bytes)
+        except ConnectionResetError:
+            return b""
 
     def send_packet(self, packet_out):
         if self._conn is None:


### PR DESCRIPTION
No fix for disconnection loops as yet.  But this does allow candidate fixes and work arounds (e.g. #935 ) for issue #893 to be tested in future.  Plus it definitively documents the current behaviour as known.  Previously, the behaviour was tricky to reproduce, relying on perfect timing.  But building on Paho.MQTT/Python's existing extensive testing tools made it possible.  

The whole point of the two new tests is that they're exactly the same except for the QoS.  However the QoS 0 one passes and the QoS 1 one fails (hence it's marked as xfail).  I claim the latter fails because the rebooted broker kicks the client.  The test simulates a client that not receive a PUBACK, by deactivating one of the client's methods that pops the message ID from self._out_messages.  This causes the client to republish 'unacknowledged' messages on reconnection.  However it also continues to use a topic alias from the previous connection, which the new Broker does not recognise, so it kicks the client.  

The QoS 0 client doesn't save messages that were attempted to be published (for a possible retry) and shouldn't receive a PUBACK anyway, so there is no reason for it to be kicked (unless the user deliberately publishes a new message, with the old connection's topic alias, that the fresh broker instance isn't set up for)

To reuse as much pre-existing code as possible,, I refactored the existing TestCase into a base class, and made some minor changes to the setUpClass and TearDown methods, to allow a second broker instance to be created the same port as any the old one (otherwise it would be a new random port).

More things are going on than I yet understand with QoS 2.  A similar corresponding naive test case with QoS2 results in the whole test session timing out (simply deactivating `_do_on_publish` probably breaks the more complex QoS 2 functionality).