### PR TITLE
Remove self._thread.join() (fix race condition in loop_stop)

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -2390,8 +2390,6 @@ class Client:
             return MQTTErrorCode.MQTT_ERR_INVAL
 
         self._thread_terminate = True
-        if threading.current_thread() != self._thread:
-            self._thread.join()
 
         return MQTTErrorCode.MQTT_ERR_SUCCESS
 

--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -2391,6 +2391,12 @@ class Client:
 
         self._thread_terminate = True
 
+        with self.lock:
+            thread = self._thread
+
+        if thread is not None:
+            thread.join()
+
         return MQTTErrorCode.MQTT_ERR_SUCCESS
 
     @property


### PR DESCRIPTION
(Over?)simple fix for #872.  

I can't pin it down, but removing the join and relying on a shared boolean feels much less robust.  

What else breaks with this change?

