### PR TITLE
Fix Ruff typing deprecations (#951)

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -35,7 +35,8 @@ import urllib.parse
 import urllib.request
 import uuid
 import warnings
-from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, NamedTuple, Sequence, Tuple, Union, cast, overload
+from collections.abc import Iterator, Sequence
+from typing import TYPE_CHECKING, Any, Callable, NamedTuple, Union, cast, overload
 
 from paho.mqtt.packettypes import PacketTypes
 
@@ -216,7 +217,7 @@ sockpair_data = b"0"
 # * None is converted to a zero-length payload (i.e. b"")
 PayloadType = Union[str, bytes, bytearray, int, float, None]
 
-HTTPHeader = Dict[str, str]
+HTTPHeader = dict[str, str]
 WebSocketHeaders = Union[Callable[[HTTPHeader], HTTPHeader], HTTPHeader]
 
 CleanStartOption = Union[bool, Literal[3]]
@@ -247,8 +248,8 @@ class DisconnectFlags(NamedTuple):
     """
 
 
-CallbackOnConnect_v1_mqtt3 = Callable[["Client", Any, Dict[str, Any], MQTTErrorCode], None]
-CallbackOnConnect_v1_mqtt5 = Callable[["Client", Any, Dict[str, Any], ReasonCode, Union[Properties, None]], None]
+CallbackOnConnect_v1_mqtt3 = Callable[["Client", Any, dict[str, Any], MQTTErrorCode], None]
+CallbackOnConnect_v1_mqtt5 = Callable[["Client", Any, dict[str, Any], ReasonCode, Union[Properties, None]], None]
 CallbackOnConnect_v1 = Union[CallbackOnConnect_v1_mqtt5, CallbackOnConnect_v1_mqtt3]
 CallbackOnConnect_v2 = Callable[["Client", Any, ConnectFlags, ReasonCode, Union[Properties, None]], None]
 CallbackOnConnect = Union[CallbackOnConnect_v1, CallbackOnConnect_v2]
@@ -265,15 +266,15 @@ CallbackOnPublish_v1 = Callable[["Client", Any, int], None]
 CallbackOnPublish_v2 = Callable[["Client", Any, int, ReasonCode, Properties], None]
 CallbackOnPublish = Union[CallbackOnPublish_v1, CallbackOnPublish_v2]
 CallbackOnSocket = Callable[["Client", Any, "SocketLike"], None]
-CallbackOnSubscribe_v1_mqtt3 = Callable[["Client", Any, int, Tuple[int, ...]], None]
-CallbackOnSubscribe_v1_mqtt5 = Callable[["Client", Any, int, List[ReasonCode], Properties], None]
+CallbackOnSubscribe_v1_mqtt3 = Callable[["Client", Any, int, tuple[int, ...]], None]
+CallbackOnSubscribe_v1_mqtt5 = Callable[["Client", Any, int, list[ReasonCode], Properties], None]
 CallbackOnSubscribe_v1 = Union[CallbackOnSubscribe_v1_mqtt3, CallbackOnSubscribe_v1_mqtt5]
-CallbackOnSubscribe_v2 = Callable[["Client", Any, int, List[ReasonCode], Union[Properties, None]], None]
+CallbackOnSubscribe_v2 = Callable[["Client", Any, int, list[ReasonCode], Union[Properties, None]], None]
 CallbackOnSubscribe = Union[CallbackOnSubscribe_v1, CallbackOnSubscribe_v2]
 CallbackOnUnsubscribe_v1_mqtt3 = Callable[["Client", Any, int], None]
-CallbackOnUnsubscribe_v1_mqtt5 = Callable[["Client", Any, int, Properties, Union[ReasonCode, List[ReasonCode]]], None]
+CallbackOnUnsubscribe_v1_mqtt5 = Callable[["Client", Any, int, Properties, Union[ReasonCode, list[ReasonCode]]], None]
 CallbackOnUnsubscribe_v1 = Union[CallbackOnUnsubscribe_v1_mqtt3, CallbackOnUnsubscribe_v1_mqtt5]
-CallbackOnUnsubscribe_v2 = Callable[["Client", Any, int, List[ReasonCode], Union[Properties, None]], None]
+CallbackOnUnsubscribe_v2 = Callable[["Client", Any, int, list[ReasonCode], Union[Properties, None]], None]
 CallbackOnUnsubscribe = Union[CallbackOnUnsubscribe_v1, CallbackOnUnsubscribe_v2]
 
 # This is needed for typing because class Client redefined the name "socket"

--- a/src/paho/mqtt/publish.py
+++ b/src/paho/mqtt/publish.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import collections
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, List, Tuple, Union
+from typing import TYPE_CHECKING, Any, Union
 
 from paho.mqtt.enums import CallbackAPIVersion, MQTTProtocolVersion
 from paho.mqtt.properties import Properties
@@ -64,9 +64,9 @@ if TYPE_CHECKING:
         qos: NotRequired[int]
         retain: NotRequired[bool]
 
-    MessageTuple = Tuple[str, paho.PayloadType, int, bool]
+    MessageTuple = tuple[str, paho.PayloadType, int, bool]
 
-    MessagesList = List[Union[MessageDict, MessageTuple]]
+    MessagesList = list[Union[MessageDict, MessageTuple]]
 
 
 def _do_publish(client: paho.Client):

--- a/tests/debug_helpers.py
+++ b/tests/debug_helpers.py
@@ -1,6 +1,5 @@
 import binascii
 import struct
-from typing import Tuple
 
 
 def dump_packet(prefix: str, data: bytes) -> None:
@@ -12,7 +11,7 @@ def dump_packet(prefix: str, data: bytes) -> None:
         print(prefix, " (not decoded): 0x", data, sep="")
 
 
-def remaining_length(packet: bytes) -> Tuple[bytes, int]:
+def remaining_length(packet: bytes) -> tuple[bytes, int]:
     l = min(5, len(packet))  # noqa: E741
     all_bytes = struct.unpack("!" + "B" * l, packet[:l])
     mult = 1


### PR DESCRIPTION
## Summary

- Replace the deprecated `typing.Dict`, `typing.List`, and `typing.Tuple`
  annotations with Python 3.9-compatible built-in generics.
- Move `Iterator` and `Sequence` imports to `collections.abc` where required.
- Keep the change limited to the three files reported by issue #951.

## Scope

Changed files:

- `src/paho/mqtt/client.py`
- `src/paho/mqtt/publish.py`
- `tests/debug_helpers.py`

The commit contains 14 additions and 14 deletions. It does not change MQTT
runtime behavior, dependencies, workflows, Ruff configuration, pre-commit
configuration, or project metadata.

## Before / after

At baseline revision `ac779fe09f4797781718fd64f045e27c37b30ce0`, the pinned
Ruff 0.1.9 check reported 18 UP006/UP035 diagnostics and exited 1. On this
branch, the same check reports zero diagnostics and exits 0.

## Verification

- Ruff 0.1.9: passed
- Pinned pre-commit Ruff hook: passed
- Focused compatibility tests: 2 passed
- Python 3.9 AST parse: passed
- Changed-file compilation: passed
- `git diff --check`: passed

The aggregate `tox -e lint` command remains non-green because existing
repository-wide Black, codespell, and Windows-typeshed mypy findings remain;
those unrelated findings are not changed here.

The latest issue discussion says PR #793 need not block this focused change
and that configuration changes should not be proposed. This PR follows that
scope and does not modify or supersede PR #793.

Addresses #951.
